### PR TITLE
fix: suppress screen startup delay

### DIFF
--- a/chroot-alpine-customize-user.sh
+++ b/chroot-alpine-customize-user.sh
@@ -23,6 +23,9 @@ chmod 0600 ~/.ssh/authorized_keys
 if ! grep -q 'screen' ~/.profile 2> /dev/null; then
     echo "screen -xRS 'awesome' -s fish" >> ~/.profile
 fi
+if ! test -e ~/.screenrc; then
+    echo "startup_message off" > ~/.screenrc
+fi
 if ! test -e ~/.bashrc; then
     ln -s .profile ~/.bashrc
 fi


### PR DESCRIPTION
Adds `startup_message off` to `~/.screenrc` during user setup, eliminating the 2-3 second delay before screen drops the user into the shell.

Without this, screen shows its splash message and waits for Enter on every attach.